### PR TITLE
Add support for setting directory

### DIFF
--- a/update.rb
+++ b/update.rb
@@ -2,6 +2,7 @@ require "dependabot/omnibus"
 
 package_manager = "nuget"
 repo = "YOUR_ORG/YOUR_PROJECT/_git/YOUR_REPO"
+directory = "."
 
 credentials = [{
   "type" => "git_source",
@@ -17,6 +18,7 @@ credentials = [{
 source = Dependabot::Source.new(
   provider: "azure",
   repo: repo,
+  directory: directory
 )
 
 fetcher = Dependabot::FileFetchers.for_package_manager(package_manager).new(


### PR DESCRIPTION
- By default, dependabot just looks in the root directory for `nuget.config`. Setting `directory` to a subdirectory (eg. `src`) allows dependabot to find nuget.config when it is located in another location.

Fixes #7